### PR TITLE
Fixed typo/issue with the cli sample command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ aws cloudformation create-stack \
   --stack-name buildkite \
   --template-url "https://s3.amazonaws.com/buildkite-aws-stack/aws-stack.json" \
   --capabilities CAPABILITY_IAM \
-  --parameters <(cat config.json)
+  --parameters "$(cat config.json)"
 ```
 
 ### Useful Stack Parameters


### PR DESCRIPTION
The prior syntax didn't work, tripping up on the ```<(cat config.json)``` argument supplied to ```--parameters``` 

This is an alternate. Another alternate is to use ```--parameters file://config.json``` - which seems to be the [AWS preference](http://docs.aws.amazon.com/cli/latest/reference/cloudformation/create-stack.html#examples).